### PR TITLE
Add local bookings cache and offline sync

### DIFF
--- a/.idea/planningMode.xml
+++ b/.idea/planningMode.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PlanningModeManager">
+    <option name="approvalStates">
+      <map>
+        <entry key="20260423-212210-1202cad4-db10-47b4-955e-d8ee768cc40e" value="true" />
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/example/andespace/data/db/BookingDao.kt
+++ b/app/src/main/java/com/example/andespace/data/db/BookingDao.kt
@@ -1,0 +1,25 @@
+package com.example.andespace.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BookingDao {
+    @Query("SELECT * FROM bookings ORDER BY date DESC, startTime DESC")
+    fun getAllBookingsFlow(): Flow<List<BookingEntity>>
+
+    @Query("SELECT * FROM bookings ORDER BY date DESC, startTime DESC")
+    suspend fun getAllBookings(): List<BookingEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(bookings: List<BookingEntity>)
+
+    @Query("DELETE FROM bookings WHERE id = :bookingId")
+    suspend fun deleteById(bookingId: String)
+
+    @Query("DELETE FROM bookings")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/example/andespace/data/db/BookingEntity.kt
+++ b/app/src/main/java/com/example/andespace/data/db/BookingEntity.kt
@@ -1,0 +1,39 @@
+package com.example.andespace.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.andespace.model.dto.BookingDto
+
+@Entity(tableName = "bookings")
+data class BookingEntity(
+    @PrimaryKey val id: String,
+    val roomId: String,
+    val date: String,
+    val startTime: String,
+    val endTime: String,
+    val purpose: String,
+    val status: String,
+    val createdAt: String?
+)
+
+fun BookingDto.toEntity() = BookingEntity(
+    id = id,
+    roomId = roomId,
+    date = date,
+    startTime = startTime,
+    endTime = endTime,
+    purpose = purpose,
+    status = status,
+    createdAt = createdAt
+)
+
+fun BookingEntity.toDto() = BookingDto(
+    id = id,
+    roomId = roomId,
+    date = date,
+    startTime = startTime,
+    endTime = endTime,
+    purpose = purpose,
+    status = status,
+    createdAt = createdAt
+)

--- a/app/src/main/java/com/example/andespace/data/db/SyncDatabase.kt
+++ b/app/src/main/java/com/example/andespace/data/db/SyncDatabase.kt
@@ -99,13 +99,15 @@ interface FavoritesDao {
 
 @SuppressLint("RestrictedApi")
 // Added local favorites cache and bumped version to 3.
+// Added local bookings cache and bumped version to 4.
 @Database(
-    entities = [PendingSyncAction::class, PendingAnalyticsEvent::class, FavoriteRoomEntity::class],
-    version = 3,
+    entities = [PendingSyncAction::class, PendingAnalyticsEvent::class, FavoriteRoomEntity::class, BookingEntity::class],
+    version = 4,
     exportSchema = false
 )
 abstract class SyncDatabase : RoomDatabase() {
     abstract fun syncActionDao(): SyncActionDao
     abstract fun analyticsDao(): AnalyticsDao
     abstract fun favoritesDao(): FavoritesDao
+    abstract fun bookingDao(): BookingDao
 }

--- a/app/src/main/java/com/example/andespace/data/repository/BookingRepository.kt
+++ b/app/src/main/java/com/example/andespace/data/repository/BookingRepository.kt
@@ -1,70 +1,138 @@
 package com.example.andespace.data.repository
 
 import android.util.Log
+import com.example.andespace.data.db.BookingDao
+import com.example.andespace.data.db.PendingSyncAction
+import com.example.andespace.data.db.SyncActionDao
+import com.example.andespace.data.db.toDto
+import com.example.andespace.data.db.toEntity
 import com.example.andespace.data.network.ApiService
+import com.example.andespace.data.network.NetworkMonitor
+import com.example.andespace.data.repository.shared.ApiException
 import com.example.andespace.data.repository.shared.httpErrorMessage
 import com.example.andespace.model.dto.BookingDto
 import com.example.andespace.model.dto.CreateBookingRequest
+import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import com.example.andespace.data.repository.shared.ApiException
 
-
-class BookingRepository(private val apiService: ApiService) {
+class BookingRepository(
+    private val apiService: ApiService,
+    private val bookingDao: BookingDao,
+    private val syncDao: SyncActionDao,
+    private val gson: Gson
+) {
     companion object {
         private const val TAG = "BookingsRepository"
+        const val ACTION_CREATE_BOOKING = "CREATE_BOOKING"
+        const val ACTION_DELETE_BOOKING = "DELETE_BOOKING"
     }
+
+    val bookings: Flow<List<BookingDto>> = bookingDao.getAllBookingsFlow().map { entities ->
+        entities.map { it.toDto() }
+    }
+
+    suspend fun refreshBookings(): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.getMyBookings()
+            if (response.isSuccessful) {
+                val bookings = response.body()?.items.orEmpty()
+                bookingDao.clearAll()
+                bookingDao.insertAll(bookings.map { it.toEntity() })
+                Result.success(Unit)
+            } else {
+                val code = response.code()
+                Result.failure(ApiException(if (code == 401) "SESSION_EXPIRED" else httpErrorMessage(code)))
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "refreshBookings exception=${e.message}", e)
+            Result.failure(Exception("No internet connection. Please check your network and try again."))
+        }
+    }
+
     suspend fun getMyBookings(): Result<List<BookingDto>> = withContext(Dispatchers.IO) {
         try {
             val response = apiService.getMyBookings()
             if (response.isSuccessful) {
-                Result.success(response.body()?.items.orEmpty())
+                val bookings = response.body()?.items.orEmpty()
+                bookingDao.clearAll()
+                bookingDao.insertAll(bookings.map { it.toEntity() })
+                Result.success(bookings)
             } else {
                 val code = response.code()
-                Result.failure(
-                    ApiException(
-                        if (code == 401) "SESSION_EXPIRED" else httpErrorMessage(
-                            code
-                        )
-                    )
-                )
+                Result.failure(ApiException(if (code == 401) "SESSION_EXPIRED" else httpErrorMessage(code)))
             }
         } catch (e: Exception) {
             Log.e(TAG, "getMyBookings exception=${e.message}", e)
-            Result.failure(Exception("No internet connection. Please check your network and try again."))
+            val cached = bookingDao.getAllBookings().map { it.toDto() }
+            if (cached.isNotEmpty()) {
+                Result.success(cached)
+            } else {
+                Result.failure(Exception("No internet connection. Please check your network and try again."))
+            }
         }
     }
 
     suspend fun createBooking(request: CreateBookingRequest): Result<BookingDto> =
         withContext(Dispatchers.IO) {
             try {
+                if (!NetworkMonitor.isOnline.value) {
+                    enqueueBookingAction(ACTION_CREATE_BOOKING, gson.toJson(request))
+                    return@withContext Result.failure(Exception("OFFLINE_SYNC_PENDING"))
+                }
+
                 val response = apiService.createBooking(request)
                 if (response.isSuccessful) {
-                    response.body()?.let { Result.success(it) }
-                        ?: Result.failure(Exception("The booking could not be confirmed. Please try again."))
+                    val booking = response.body()
+                    if (booking != null) {
+                        bookingDao.insertAll(listOf(booking.toEntity()))
+                        Result.success(booking)
+                    } else {
+                        Result.failure(Exception("The booking could not be confirmed. Please try again."))
+                    }
                 } else {
                     Result.failure(ApiException(httpErrorMessage(response.code())))
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "createBooking exception=${e.message}", e)
-                Result.failure(Exception("No internet connection. Please check your network and try again."))
+                enqueueBookingAction(ACTION_CREATE_BOOKING, gson.toJson(request))
+                Result.failure(Exception("OFFLINE_SYNC_PENDING"))
             }
         }
 
     suspend fun deleteBooking(bookingId: String): Result<Boolean> =
         withContext(Dispatchers.IO) {
             try {
+                // Optimistic local delete
+                bookingDao.deleteById(bookingId)
+
+                if (!NetworkMonitor.isOnline.value) {
+                    enqueueBookingAction(ACTION_DELETE_BOOKING, bookingId)
+                    return@withContext Result.success(true)
+                }
+
                 val response = apiService.deleteBooking(bookingId)
                 if (response.isSuccessful || response.code() == 204) {
                     Result.success(true)
                 } else {
-                    Result.failure(ApiException(httpErrorMessage(response.code())))
+                    enqueueBookingAction(ACTION_DELETE_BOOKING, bookingId)
+                    Result.success(true) // Return success because it's enqueued
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "deleteBooking exception=${e.message}", e)
-                Result.failure(Exception("No internet connection. Please check your network and try again."))
-
+                enqueueBookingAction(ACTION_DELETE_BOOKING, bookingId)
+                Result.success(true)
             }
         }
-    
+
+    private suspend fun enqueueBookingAction(actionType: String, payload: String) {
+        syncDao.insertAction(
+            PendingSyncAction(
+                actionType = actionType,
+                payload = payload
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/example/andespace/data/repository/SyncManager.kt
+++ b/app/src/main/java/com/example/andespace/data/repository/SyncManager.kt
@@ -6,6 +6,7 @@ import com.example.andespace.data.db.SyncActionDao
 import com.example.andespace.data.network.ApiService
 import com.example.andespace.data.network.NetworkMonitor
 import com.example.andespace.model.dto.AnalyticsEventRequest
+import com.example.andespace.model.dto.CreateBookingRequest
 import com.example.andespace.model.dto.ManualClassIn
 import com.example.andespace.model.dto.RoomGapSearchAnalyticsRequest
 import com.google.gson.Gson
@@ -21,6 +22,7 @@ class SyncManager(
     private val syncDao: SyncActionDao,
     private val analyticsDao: AnalyticsDao,
     private val scheduleRepository: ScheduleRepository,
+    private val bookingRepository: BookingRepository,
     private val apiService: ApiService,
     private val gson: Gson
 ) {
@@ -94,6 +96,13 @@ class SyncManager(
                             // Favorites are flushed by FavoritesRepository to preserve local-first semantics.
                             continue
                         }
+                        "CREATE_BOOKING" -> {
+                            val request = gson.fromJson(action.payload, CreateBookingRequest::class.java)
+                            apiService.createBooking(request)
+                        }
+                        "DELETE_BOOKING" -> {
+                            apiService.deleteBooking(action.payload)
+                        }
                         else -> {
                             Log.w("SyncManager", "Unknown sync action type=${action.actionType}, keeping it in queue")
                             continue
@@ -110,6 +119,7 @@ class SyncManager(
 
             if (!networkFailed) {
                 scheduleRepository.syncEntireScheduleFromBackend()
+                bookingRepository.refreshBookings()
             }
         }
     }

--- a/app/src/main/java/com/example/andespace/di/AppContainer.kt
+++ b/app/src/main/java/com/example/andespace/di/AppContainer.kt
@@ -16,6 +16,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.example.andespace.BuildConfig
 import com.example.andespace.data.db.AnalyticsDao
+import com.example.andespace.data.db.BookingDao
 import com.example.andespace.data.db.FavoritesDao
 import com.example.andespace.data.db.SyncDatabase
 import com.example.andespace.data.network.AuthInterceptor
@@ -39,6 +40,7 @@ interface AppContainer {
     val analyticsDao: AnalyticsDao
     val syncDao: SyncActionDao
     val favoritesDao: FavoritesDao
+    val bookingDao: BookingDao
 }
 
 class DefaultAppContainer(private val context: Context) : AppContainer {
@@ -64,13 +66,32 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
         }
     }
 
+    private val migration3To4 = object : Migration(3, 4) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `bookings` (
+                    `id` TEXT PRIMARY KEY NOT NULL,
+                    `roomId` TEXT NOT NULL,
+                    `date` TEXT NOT NULL,
+                    `startTime` TEXT NOT NULL,
+                    `endTime` TEXT NOT NULL,
+                    `purpose` TEXT NOT NULL,
+                    `status` TEXT NOT NULL,
+                    `createdAt` TEXT
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
     private val syncDatabase: SyncDatabase by lazy {
         Room.databaseBuilder(
             context,
             SyncDatabase::class.java,
             "andespace_sync_database"
         )
-            .addMigrations(migration2To3)
+            .addMigrations(migration2To3, migration3To4)
             .fallbackToDestructiveMigration(false)
             .build()
     }
@@ -135,6 +156,10 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
         syncDatabase.favoritesDao()
     }
 
+    override val bookingDao: BookingDao by lazy {
+        syncDatabase.bookingDao()
+    }
+
     override val analyticsRepository: AnalyticsRepository by lazy {
         AnalyticsRepository(apiService, analyticsDao, gson)
     }
@@ -144,7 +169,7 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
     }
 
     override val bookingRepository: BookingRepository by lazy {
-        BookingRepository(apiService)
+        BookingRepository(apiService, bookingDao, syncDao, gson)
     }
 
     override val scheduleRepository: ScheduleRepository by lazy {
@@ -152,6 +177,6 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
     }
 
     override val syncManager: SyncManager by lazy {
-        SyncManager(syncDao, analyticsDao, scheduleRepository, apiService, gson)
+        SyncManager(syncDao, analyticsDao, scheduleRepository, bookingRepository, apiService, gson)
     }
 }

--- a/app/src/main/java/com/example/andespace/ui/bookings/BookingsUIState.kt
+++ b/app/src/main/java/com/example/andespace/ui/bookings/BookingsUIState.kt
@@ -12,10 +12,12 @@ data class BookingsUIState(
     val selectedBooking: BookingDto? = null,
     val contentScreen: BookingsContentScreen = BookingsContentScreen.LIST,
     val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
     val isSaving: Boolean = false,
     val isCreating: Boolean = false,
     val createError: String? = null,
     val bookingCreatedSuccess: Boolean = false,
     val errorMessage: String? = null,
+    val syncMessage: String? = null,
     val requiresLogin: Boolean = false
 )

--- a/app/src/main/java/com/example/andespace/ui/bookings/BookingsViewModel.kt
+++ b/app/src/main/java/com/example/andespace/ui/bookings/BookingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.andespace.model.dto.BookingDto
 import com.example.andespace.model.dto.CreateBookingRequest
 import com.example.andespace.data.repository.BookingRepository
+import com.example.andespace.data.network.NetworkMonitor
 import com.example.andespace.ui.common.UserMessages
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,13 +17,37 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
     private val _uiState = MutableStateFlow(BookingsUIState())
     val uiState: StateFlow<BookingsUIState> = _uiState.asStateFlow()
 
+    init {
+        observeBookings()
+        loadBookings()
+        observeNetwork()
+    }
+
+    private fun observeBookings() {
+        viewModelScope.launch {
+            repository.bookings.collect { bookings ->
+                _uiState.update { it.copy(bookings = bookings) }
+            }
+        }
+    }
+
+    private fun observeNetwork() {
+        viewModelScope.launch {
+            NetworkMonitor.isOnline.collect { isOnline ->
+                if (isOnline) {
+                    refreshBookings()
+                }
+            }
+        }
+    }
+
     fun loadBookings() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null, requiresLogin = false) }
             repository.getMyBookings()
                 .onSuccess { bookings ->
                     _uiState.update {
-                        it.copy(bookings = bookings, isLoading = false)
+                        it.copy(isLoading = false)
                     }
                 }
                 .onFailure { error ->
@@ -35,6 +60,14 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
                         )
                     }
                 }
+        }
+    }
+
+    private fun refreshBookings() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+            repository.refreshBookings()
+            _uiState.update { it.copy(isRefreshing = false) }
         }
     }
 
@@ -52,12 +85,7 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             repository.deleteBooking(booking.id)
                 .onSuccess {
-                    _uiState.update { state ->
-                        state.copy(
-                            bookings = state.bookings.filter { it.id != booking.id },
-                            isLoading = false
-                        )
-                    }
+                    _uiState.update { it.copy(isLoading = false) }
                 }
                 .onFailure { _ ->
                     _uiState.update {
@@ -90,11 +118,21 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
                     }
                     loadBookings()
                 }
-                .onFailure { _ ->
-                    _uiState.update {
-                        it.copy(isSaving = false, errorMessage = UserMessages.SAVE_BOOKING_FAILED)
+                .onFailure { error ->
+                    if (error.message == "OFFLINE_SYNC_PENDING") {
+                        _uiState.update {
+                            it.copy(
+                                selectedBooking = null,
+                                isSaving = false,
+                                contentScreen = BookingsContentScreen.LIST,
+                                syncMessage = UserMessages.BOOKING_PENDING_SYNC
+                            )
+                        }
+                    } else {
+                        _uiState.update {
+                            it.copy(isSaving = false, errorMessage = UserMessages.SAVE_BOOKING_FAILED)
+                        }
                     }
-                    loadBookings()
                 }
         }
     }
@@ -118,8 +156,18 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
                     }
                 }
                 .onFailure { error ->
-                    _uiState.update {
-                        it.copy(isCreating = false, createError = friendlyError(error.message))
+                    if (error.message == "OFFLINE_SYNC_PENDING") {
+                        _uiState.update {
+                            it.copy(
+                                isCreating = false,
+                                bookingCreatedSuccess = true, // We treat it as success to close the screen
+                                syncMessage = UserMessages.BOOKING_PENDING_SYNC
+                            )
+                        }
+                    } else {
+                        _uiState.update {
+                            it.copy(isCreating = false, createError = friendlyError(error.message))
+                        }
                     }
                 }
         }
@@ -129,6 +177,10 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
         _uiState.update { it.copy(bookingCreatedSuccess = false) }
     }
 
+    fun consumeSyncMessage() {
+        _uiState.update { it.copy(syncMessage = null) }
+    }
+
 
     fun resetRequiresLogin() {
         _uiState.update { it.copy(requiresLogin = false) }
@@ -136,6 +188,7 @@ class BookingsViewModel(private val repository: BookingRepository): ViewModel() 
 
     private fun friendlyError(raw: String?): String = when {
         raw == null -> UserMessages.GENERIC_ERROR
+        raw == "OFFLINE_SYNC_PENDING" -> UserMessages.BOOKING_PENDING_SYNC
         raw.startsWith("No internet connection") -> UserMessages.NO_INTERNET
         raw.startsWith("Network error") -> UserMessages.NO_INTERNET
         raw.matches(Regex("Error \\d+.*")) -> UserMessages.GENERIC_ERROR

--- a/app/src/main/java/com/example/andespace/ui/common/UserMessages.kt
+++ b/app/src/main/java/com/example/andespace/ui/common/UserMessages.kt
@@ -6,4 +6,6 @@ object UserMessages {
     const val DELETE_BOOKING_FAILED = "Could not delete the booking. Please try again."
     const val SAVE_BOOKING_FAILED = "Could not save the booking. Please try again."
     const val FAVORITES_SYNC_FAILED = "Couldn't sync favorites right now. Showing local favorites."
+    const val BOOKING_PENDING_SYNC = "No internet connection. Booking will be synced once online."
+    const val BOOKING_SYNCED = "Your bookings have been synchronized."
 }


### PR DESCRIPTION
Introduce local bookings persistence and offline sync support. Adds BookingEntity and BookingDao, exposes a bookings Flow, and updates SyncDatabase to version 4 with a migration to create the bookings table. BookingRepository now caches bookings, returns cached results when offline, enqueues create/delete actions as PendingSyncAction (CREATE_BOOKING / DELETE_BOOKING) and uses NetworkMonitor/Gson for offline handling. SyncManager is extended to flush queued booking actions and refresh bookings after sync. Wire up bookingDao, repository, and sync manager in AppContainer, update BookingsViewModel/UI state to observe live bookings and network changes, add user messages for pending sync, and include an IDE planningMode config file.